### PR TITLE
Feedback: nullable vs lateinit

### DIFF
--- a/src/test/kotlin/com/acme/hellospring/controllers/GreetingControllerTest.kt
+++ b/src/test/kotlin/com/acme/hellospring/controllers/GreetingControllerTest.kt
@@ -17,6 +17,11 @@ class GreetingControllerTest {
         @Autowired
         lateinit var mockMvc: MockMvc;
 
+        val nullMockMvc: MockMvc? = null;
+
+        @Autowired
+        val notNullMockMvc: MockMvc? = null;
+
         @Test
         fun greetingShouldReturnDefaultMessage() {
                 this.mockMvc.perform(
@@ -38,4 +43,26 @@ class GreetingControllerTest {
                     content().string(containsString("hello Trinh"))
                 );
         }
+
+    @Test
+    fun `this test should not pass but unfortunately it does`() {
+        this.nullMockMvc?.perform(
+            get("/v1/hello/world").param("name", "LAZZA")
+        )?.andExpect(
+            status().isAccepted()
+        )?.andExpect(
+            content().string(containsString("THIS TEST WILL PASS FOR THE WRONG REASONS"))
+        )
+    }
+
+    @Test
+    fun `this test will fail as you expect`() {
+        this.notNullMockMvc?.perform(
+            get("/v1/hello/world").param("name", "LAZZA")
+        )?.andExpect(
+            status().isAccepted()
+        )?.andExpect(
+            content().string(containsString("THIS TEST WILL NOT PASS"))
+        )
+    }
 }

--- a/src/test/kotlin/com/acme/hellospring/controllers/GreetingControllerTest.kt
+++ b/src/test/kotlin/com/acme/hellospring/controllers/GreetingControllerTest.kt
@@ -15,18 +15,27 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 @AutoConfigureMockMvc
 class GreetingControllerTest {
         @Autowired
-        private var mockMvc: MockMvc? = null;
-
+        lateinit var mockMvc: MockMvc;
 
         @Test
         fun greetingShouldReturnDefaultMessage() {
-                this.mockMvc?.perform(get("/v1/hello/world"))?.andExpect(status().isOk())
-                        ?.andExpect(content().string(containsString("hello world")));
+                this.mockMvc.perform(
+                    get("/v1/hello/world")
+                ).andExpect(
+                    status().isOk()
+                ).andExpect(
+                    content().string(containsString("hello world"))
+                );
         }
 
         @Test
         fun greetingShouldReturnSpecificMessage() {
-                this.mockMvc?.perform(get("/v1/hello/world").param("name", "Trinh"))?.andExpect(status().isOk())
-                        ?.andExpect(content().string(containsString("hello Trinh")));
+                this.mockMvc.perform(
+                    get("/v1/hello/world").param("name", "Trinh")
+                ).andExpect(
+                    status().isOk()
+                ).andExpect(
+                    content().string(containsString("hello Trinh"))
+                );
         }
 }


### PR DESCRIPTION
Ok, here's a quick PR with a change on the tests.

Instead of using nullable and null-safe accessors on the assertion change, I'm changing to a `lateinit` var.

By using null safe access, the assertions will never get called if the `mockMvc` object was null to begin with. It shouldn't happen in your specific scenario, but we might as well play it safe, and have a clear failure.